### PR TITLE
Change currentSerialNumber to use unix time

### DIFF
--- a/mitm/mitm.go
+++ b/mitm/mitm.go
@@ -20,7 +20,7 @@ import (
 
 // While generating a new certificate, in order to get a unique serial
 // number every time we increment this value.
-var currentSerialNumber int64
+var currentSerialNumber int64 = time.Now().Unix()
 
 // Config is a set of configuration values that are used to build TLS configs
 // capable of MITM.


### PR DESCRIPTION
This prevents serial reuse errors after restarting the proxy. In theory, this could cause problems the proxy is reloaded too quickly (to be precise if the time between 2 started instances of the proxy in seconds is less than the amount of certs generated) but that seems unlikely and could be solved by moving to microseconds or nanoseconds