### PR TITLE
Allow to configure cipher suite and TLS min version

### DIFF
--- a/mitm/mitm.go
+++ b/mitm/mitm.go
@@ -42,6 +42,11 @@ type Config struct {
 
 	certsStorage   CertsStorage // cache with the generated certificates
 	certsStorageMu sync.RWMutex
+
+	// Set a custom suite of ciphers to accept from remote servers. Nil to use the go default.
+	TlsAcceptCipherSuites []uint16
+	// Set a custom minimum TLS version to accept from remote servers. 0 to use the go default.
+	TlsMinVersion uint16
 }
 
 // CertsStorage is an interface for generated tls certificates storage

--- a/proxy.go
+++ b/proxy.go
@@ -67,6 +67,8 @@ func NewProxy(config Config) *Proxy {
 					// In this case we'll receive the error and will be able to add the host to invalidTLSHosts
 					return nil, errClientCertRequested
 				},
+				MinVersion:   config.MITMConfig.TlsMinVersion,
+				CipherSuites: config.MITMConfig.TlsAcceptCipherSuites,
 			},
 		},
 		timeout:         defaultTimeout,


### PR DESCRIPTION
Go ships with reasonable defaults. But an application might want to set a stricter (or looser) cipher suite and min version.