### PR TITLE
Fix Panic in Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ proxy := gomitmproxy.NewProxy(gomitmproxy.Config{
         log.Printf("onResponse: %s", session.Request().URL.String())
 
         if _, ok := session.GetProp("blocked"); ok {
-            log.Printf("onResponse: was blocked")
+            blocked, _ := session.GetProp("blocked")
+            if blocked.(bool) {
+                log.Printf("onResponse: was blocked")
+            }
         }
 
         res := session.Response()


### PR DESCRIPTION
Hey,
in the Readme Example chapter Modifying requests and responses the OnResponse Function only checked for the existence of the blocked variable, not if the boolean value was actually true.
So if session.SetProp("blocked", false) is set in OnRequest to indicate that the Request was NOT blocked, the OnResponse function will still return "onResponse: was blocked"
Cheers, [JM-Lemmi](https://github.com/jm-lemmi)